### PR TITLE
Fix playerctl crash on media app close via signal-based caching

### DIFF
--- a/widgets/playerctl.py
+++ b/widgets/playerctl.py
@@ -96,35 +96,43 @@ class PlayerctlMenu(Popover):
         self._update_play_pause_icon()
 
     def _on_play_pause_clicked(self, *args):
-        if not self.player or not getattr(self.player, "props", None):
+        if not self.player:
             return
         try:
-            if self.player.props.playback_status == Playerctl.PlaybackStatus.PLAYING:
-                self.player.pause()
+            status = getattr(self, "_last_playback_status", None)
+            if status == Playerctl.PlaybackStatus.PLAYING:
+                try:
+                    self.player.pause()
+                except Exception:
+                    pass
             else:
-                self.player.play()
+                try:
+                    self.player.play()
+                except Exception:
+                    pass
         except Exception as e:
             print(f"Error toggling play/pause: {e}")
 
     def _on_skip_back_clicked(self, *args):
-        if self.player and getattr(self.player, "props", None):
-            try:
-                self.player.previous()
-            except Exception as e:
-                print(f"Error skipping back: {e}")
-
-    def _on_skip_forward_clicked(self, *args):
-        if self.player and getattr(self.player, "props", None):
-            try:
-                self.player.next()
-            except Exception as e:
-                print(f"Error skipping forward: {e}")
-
-    def _update_play_pause_icon(self):
-        if not self.player or not getattr(self.player, "props", None):
+        if not self.player:
             return
         try:
-            status = self.player.props.playback_status
+            self.player.previous()
+        except Exception as e:
+            print(f"Error skipping back: {e}")
+
+    def _on_skip_forward_clicked(self, *args):
+        if not self.player:
+            return
+        try:
+            self.player.next()
+        except Exception as e:
+            print(f"Error skipping forward: {e}")
+
+    def _update_play_pause_icon(self):
+        # Use cached playback status to update icon; avoid accessing player.props
+        try:
+            status = getattr(self, "_last_playback_status", None)
             icon_name = (
                 icons["playerctl"]["playing"]
                 if status == Playerctl.PlaybackStatus.PLAYING
@@ -142,32 +150,23 @@ class PlayerctlMenu(Popover):
 
     @run_in_thread
     def _update_track_info_async(self):
-        if not self.player or not getattr(self.player, "props", None):
-            GLib.idle_add(self._reset_display)
-            return
-        metadata = getattr(self.player.props, "metadata", None)
-        if not metadata:
-            GLib.idle_add(self._reset_display)
-            return
+        # Use cached metadata to update menu; avoid reading player.props or get_position
         try:
-            md = dict(metadata.unpack())
+            md = getattr(self, "_last_metadata", {}) or {}
+            if not md:
+                GLib.idle_add(self._reset_display)
+                return
             title = md.get("xesam:title", "")
             artist = (md.get("xesam:artist") or [""])[0]
-            length_us = md.get("mpris:length", 0)
-            pos_us = getattr(self.player, "get_position", lambda: 0)()
-
-            cur_sec, total_sec = int(pos_us / 1e6), int(length_us / 1e6)
-            cur_min, cur_s = divmod(cur_sec, 60)
-            tot_min, tot_s = divmod(total_sec, 60)
-            time_text = f"{cur_min}:{cur_s:02} / {tot_min}:{tot_s:02}"
+            time_text = "0:00 / 0:00"
 
             GLib.idle_add(
                 self._update_labels_and_slider,
                 title,
                 artist,
                 time_text,
-                cur_sec,
-                total_sec,
+                0,
+                1,
             )
             self._update_play_pause_icon()
         except Exception as e:
@@ -190,7 +189,7 @@ class PlayerctlMenu(Popover):
         return True
 
     def _on_slider_click(self, widget, event):
-        if not self.player or not getattr(self.player, "props", None):
+        if not self.player:
             return False
         alloc = widget.get_allocation()
         if alloc.width <= 0:
@@ -202,9 +201,15 @@ class PlayerctlMenu(Popover):
 
         try:
             if hasattr(self.player, "set_position"):
-                self.player.set_position(seek_sec * 1_000_000)
+                try:
+                    self.player.set_position(seek_sec * 1_000_000)
+                except Exception:
+                    pass
             if hasattr(self.player, "play"):
-                self.player.play()
+                try:
+                    self.player.play()
+                except Exception:
+                    pass
         except Exception as e:
             print(f"Error seeking in track: {e}")
         return False
@@ -234,6 +239,11 @@ class PlayerctlWidget(EventBoxWidget):
         self.poll_interval = config.get("poll_interval", 2000)
         self.player = None
         self.popup = None
+        self._last_metadata = {}
+        self._last_playback_status = None
+        self._metadata_handler_id = None
+        self._playback_handler_id = None
+        self.player_name = None
 
         self.player_manager = Playerctl.PlayerManager.new()
 
@@ -304,13 +314,68 @@ class PlayerctlWidget(EventBoxWidget):
 
     @run_in_thread
     def _on_metadata_changed(self, player, metadata=None):
-        if not self.player or not getattr(player, "props", None):
-            return
-        md = dict(player.props.metadata.unpack()) if player.props.metadata else {}
-        title = md.get("xesam:title", "")
-        artist = (md.get("xesam:artist") or [""])[0]
-        display_text = f"{title} – {artist}" if artist else title
-        GLib.idle_add(self._update_label_text, display_text)
+        # Use the metadata argument passed by the signal when possible to avoid
+        # accessing `player.props` which can invoke g_object_get_property and
+        # crash if the player has vanished.
+        try:
+            md = {}
+            if metadata:
+                try:
+                    md = dict(metadata.unpack())
+                except Exception:
+                    md = {}
+            # cache metadata for menu/other UI use
+            self._last_metadata = md
+            title = md.get("xesam:title", "")
+            artist = (md.get("xesam:artist") or [""])[0]
+            display_text = f"{title} – {artist}" if artist else title
+            GLib.idle_add(self._update_label_text, display_text)
+        except Exception as e:
+            print(f"Error in metadata handler: {e}")
+
+    def _on_playback_status_changed(self, player, status):
+        """Cache playback status from signal to avoid reading player.props."""
+        try:
+            self._last_playback_status = status
+            GLib.idle_add(self._update_play_pause_icon_from_status, status)
+        except Exception as e:
+            print(f"Error in playback status handler: {e}")
+
+    def _update_play_pause_icon_from_status(self, status):
+        """Update play/pause icon based on playback status (called from main thread)."""
+        try:
+            icon_name = (
+                icons["playerctl"]["playing"]
+                if status == Playerctl.PlaybackStatus.PLAYING
+                else icons["playerctl"]["paused"]
+            )
+            if self.popup and hasattr(self.popup, "_set_play_pause_icon"):
+                self.popup._set_play_pause_icon(icon_name)
+        except Exception as e:
+            print(f"Error updating play/pause from status: {e}")
+
+    def _fetch_initial_metadata(self):
+        """Request initial metadata from player by checking playback status.
+        
+        This indirectly triggers metadata signal to fire without directly reading props.
+        """
+        if not self.player:
+            return False
+        try:
+            # Call playback_status() to trigger any pending signals
+            # Don't read the return value, just call the method to nudge the player
+            try:
+                _ = self.player.call_playback_status_sync()
+            except Exception:
+                pass
+            # Also try calling get_metadata() if available
+            try:
+                _ = self.player.call_metadata_sync()
+            except Exception:
+                pass
+        except Exception:
+            pass
+        return False  # Don't reschedule
 
     def _update_label_text(self, text):
         self.label.set_text(text)
@@ -320,47 +385,134 @@ class PlayerctlWidget(EventBoxWidget):
             self.popup._update_track_info_async()
 
     def _setup_initial_player(self):
-        player_names = self.player_manager.props.player_names
+        try:
+            player_names = self.player_manager.props.player_names
+        except Exception:
+            player_names = []
+
         if player_names and isinstance(player_names[0], Playerctl.PlayerName):
-            player = Playerctl.Player.new_from_name(player_names[0])
-            self._set_player(player)
+            try:
+                player = Playerctl.Player.new_from_name(player_names[0])
+                self._set_player(player)
+            except Exception:
+                pass
 
     def _poll_players(self):
-        player_names = self.player_manager.props.player_names
+        try:
+            player_names = self.player_manager.props.player_names
+        except Exception:
+            player_names = []
+
         if not player_names and self.player:
             self._clear_player()
         elif player_names:
-            current = (
-                getattr(self.player.props, "player_name", None) if self.player else None
-            )
+            current = None
+            try:
+                current = self.player_name if self.player else None
+            except Exception:
+                current = None
             available = [p for p in player_names]
             if current not in available:
-                player = Playerctl.Player.new_from_name(available[0])
-                self._set_player(player)
+                try:
+                    player = Playerctl.Player.new_from_name(available[0])
+                    self._set_player(player)
+                except Exception:
+                    pass
         return True
 
     def _on_player_vanished(self, _, player):
-        if self.player and getattr(player, "props", None):
-            if player.props.player_name == self.player.props.player_name:
-                self._clear_player()
+        try:
+            # Clear references immediately if the vanished player matches
+            # the current player name. Avoid accessing player.props on the
+            # vanished object where possible.
+            try:
+                vanished_name = None
+                try:
+                    vanished_name = player.props.player_name
+                except Exception:
+                    vanished_name = None
+                if vanished_name and self.player_name and vanished_name == self.player_name:
+                    self._clear_player()
+            except Exception:
+                # Fallback: if we have a player object but can't read names,
+                # just clear to be safe.
+                if self.player:
+                    self._clear_player()
+        except Exception as e:
+            print(f"Error in player vanished handler: {e}")
 
     def _on_player_appeared(self, _, player_name_obj):
         if not self.player and isinstance(player_name_obj, Playerctl.PlayerName):
-            player = Playerctl.Player.new_from_name(player_name_obj)
-            self._set_player(player)
+            try:
+                player = Playerctl.Player.new_from_name(player_name_obj)
+                self._set_player(player)
+            except Exception:
+                pass
 
     def _set_player(self, player):
+        # Disconnect old handlers safely
         if self.player:
             try:
-                self.player.disconnect_by_func(self._on_metadata_changed)
-            except TypeError:
+                if getattr(self, "_metadata_handler_id", None) is not None:
+                    try:
+                        self.player.disconnect(self._metadata_handler_id)
+                    except Exception:
+                        try:
+                            self.player.disconnect_by_func(self._on_metadata_changed)
+                        except Exception:
+                            pass
+            except Exception:
                 pass
+
         self.player = player
+        # Reset caches
+        self._last_metadata = {}
+        self._last_playback_status = None
+        self.player_name = None
+        self._metadata_handler_id = None
+        self._playback_handler_id = None
+
         if player:
-            player.connect("metadata", self._on_metadata_changed)
-            self._on_metadata_changed(player)
+            try:
+                # Connect metadata signal and store handler id
+                try:
+                    self._metadata_handler_id = player.connect("metadata", self._on_metadata_changed)
+                except Exception:
+                    self._metadata_handler_id = None
+                # Connect playback status changes if available
+                try:
+                    self._playback_handler_id = player.connect("playback-status", self._on_playback_status_changed)
+                except Exception:
+                    self._playback_handler_id = None
+                
+                # Schedule a deferred initial metadata fetch on the main thread
+                # This avoids race conditions and lets signals settle first
+                GLib.idle_add(self._fetch_initial_metadata)
+            except Exception as e:
+                print(f"Error setting up player: {e}")
 
     def _clear_player(self):
+        # Disconnect any stored handlers from the current player before clearing
+        try:
+            if self.player:
+                if getattr(self, "_metadata_handler_id", None) is not None:
+                    try:
+                        self.player.disconnect(self._metadata_handler_id)
+                    except Exception:
+                        try:
+                            self.player.disconnect_by_func(self._on_metadata_changed)
+                        except Exception:
+                            pass
+                if getattr(self, "_playback_handler_id", None) is not None:
+                    try:
+                        self.player.disconnect(self._playback_handler_id)
+                    except Exception:
+                        try:
+                            self.player.disconnect_by_func(self._on_playback_status_changed)
+                        except Exception:
+                            pass
+        except Exception:
+            pass
         self.player = None
         self.label.set_text("")
         if self.tooltip_enabled:


### PR DESCRIPTION
Avoid g_object_get_property crashes by caching metadata/status from
signal arguments instead of reading player.props. Track and disconnect
handlers properly. Wrap D-Bus operations safely.

> I had to vibecode my way through this one. It's not perfect, but
  it works somewhat fine without crashes.
